### PR TITLE
chore(package.json): rename package to nestjs-google-pubsub-connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@flosportsinc/nestjs-google-pubsub-microservice",
+  "name": "@flosportsinc/nestjs-google-pubsub-connector",
   "version": "0.0.0-development",
-  "description": "A NestJS Custom Transport Strategy for Google PubSub",
+  "description": "A NestJS Connector for Google PubSub",
   "main": "dist/index.js",
   "repository": {
-    "url": "git+https://github.com/flocasts/nestjs-google-pubsub-microservice.git",
+    "url": "git+https://github.com/flocasts/nestjs-google-pubsub-connector.git",
     "type": "git"
   },
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: Users will need to change their dependency to the new
package name